### PR TITLE
Reveal onbuild

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,7 @@ services:
       - elastic2
       - elastic3
   slides:
-    image: spantree/reveal:3.4.0
+    build: slides
     ports:
       - "9000:9000"
       - "35729:35729" # to enable live reloading
@@ -81,6 +81,4 @@ services:
       INQUISITOR_URL: http://localhost:9400
       EXERCISES_URL: http://localhost:9500
     volumes:
-      - ./slides:/usr/src/slides
-      - /usr/src/slides/node_modules
-      - /usr/src/slides/bower_components
+      - ./slides/slides:/usr/src/slides/slides

--- a/exercises/mapping-and-analysis.sense
+++ b/exercises/mapping-and-analysis.sense
@@ -683,7 +683,7 @@ GET /spantree-parent-child/employee/_search
       "type": "pet",
       "query": {
         "query_string": {
-          "query": "type:dog name:starsky"
+          "query": "type:dog AND name:starsky"
         }
       }
     }

--- a/slides/Dockerfile
+++ b/slides/Dockerfile
@@ -1,0 +1,1 @@
+FROM spantree/reveal:3.4.0-onbuild

--- a/slides/Gruntfile.coffee
+++ b/slides/Gruntfile.coffee
@@ -107,6 +107,7 @@ module.exports = (grunt) ->
     # Load all grunt tasks.
     require('load-grunt-tasks')(grunt)
 
+    grunt.registerTask 'build', ['buildIndex']
     grunt.registerTask 'buildIndex',
         'Build index.html from templates/_index.html and slides/list.json.',
         ->

--- a/slides/slides/indexing.md
+++ b/slides/slides/indexing.md
@@ -46,7 +46,7 @@ You can also add/remove/update documents in bulk using the Bulk API. This is rec
 * Refresh intervals control how often newly indexed data is made available for search
 * New segments are created in the file system on each refresh
 * Smaller segments eventually merged with bigger ones
-* Segments are replicated between primaries and masters
+* Segments are replicated between primaries and replicas
 * Queries can be run as sync (default), primary only or async
 
 ---


### PR DESCRIPTION
NOTE: We will need to merge and publish the `spantree/reveal:3.4.0-onbuild` image prior to this being fully operational.  